### PR TITLE
매장 리스트 페이지

### DIFF
--- a/src/components/molecules/Reservation.tsx
+++ b/src/components/molecules/Reservation.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 
-export interface ReservationItemProps {
-  storeId: number;
-  memberId: number;
-  name: string;
-  location: string;
-  description: string;
-}
+import { ReservationItemProps } from '../../store/_reducer/reservation';
 
 const ReservationItem: React.FC<ReservationItemProps> = ({
   description,

--- a/src/components/molecules/Reservation.tsx
+++ b/src/components/molecules/Reservation.tsx
@@ -7,21 +7,29 @@ import { BoxProps, Tr, Td } from '@chakra-ui/react';
 import CustomButton from '../atoms/Button';
 
 const ReservationItem: React.FC<
-  ReservationItemProps & { style?: BoxProps }
-> = ({ description, location, memberId, name, storeId, style }) => {
+  ReservationItemProps & {
+    style?: BoxProps;
+    index: number;
+    onClick: (id: number) => void;
+  }
+> = ({
+  description,
+  location,
+  memberId,
+  name,
+  storeId,
+  style,
+  index,
+  onClick,
+}) => {
   return (
-    <Tr
-      display={'grid'}
-      gridTemplateColumns={'1fr 1fr 1fr 3fr 1fr'}
-      alignItems={'center'}
-      {...style}
-    >
-      <Td>1</Td>
+    <Tr display={'grid'} gridTemplateColumns={'1fr 1fr 1fr 3fr 1fr'} {...style}>
+      <Td>{index}</Td>
       <Td>{name}</Td>
       <Td>{location}</Td>
       <Td>{description}</Td>
       <Td>
-        <CustomButton>예약</CustomButton>
+        <CustomButton onClick={() => onClick(storeId)}>예약</CustomButton>
       </Td>
     </Tr>
   );

--- a/src/components/molecules/Reservation.tsx
+++ b/src/components/molecules/Reservation.tsx
@@ -2,14 +2,18 @@ import React from 'react';
 
 import { ReservationItemProps } from '../../store/_reducer/reservation';
 
-const ReservationItem: React.FC<ReservationItemProps> = ({
-  description,
-  location,
-  memberId,
-  name,
-  storeId,
-}) => {
-  return <div></div>;
+import { Box, BoxProps } from '@chakra-ui/react';
+
+const ReservationItem: React.FC<
+  ReservationItemProps & { style?: BoxProps }
+> = ({ description, location, memberId, name, storeId, style }) => {
+  return (
+    <Box {...style}>
+      <div>{name}</div>
+      <div>{location}</div>
+      <div>{description}</div>
+    </Box>
+  );
 };
 
 export default ReservationItem;

--- a/src/components/molecules/Reservation.tsx
+++ b/src/components/molecules/Reservation.tsx
@@ -2,17 +2,28 @@ import React from 'react';
 
 import { ReservationItemProps } from '../../store/_reducer/reservation';
 
-import { Box, BoxProps } from '@chakra-ui/react';
+import { BoxProps, Tr, Td } from '@chakra-ui/react';
+
+import CustomButton from '../atoms/Button';
 
 const ReservationItem: React.FC<
   ReservationItemProps & { style?: BoxProps }
 > = ({ description, location, memberId, name, storeId, style }) => {
   return (
-    <Box {...style}>
-      <div>{name}</div>
-      <div>{location}</div>
-      <div>{description}</div>
-    </Box>
+    <Tr
+      display={'grid'}
+      gridTemplateColumns={'1fr 1fr 1fr 3fr 1fr'}
+      alignItems={'center'}
+      {...style}
+    >
+      <Td>1</Td>
+      <Td>{name}</Td>
+      <Td>{location}</Td>
+      <Td>{description}</Td>
+      <Td>
+        <CustomButton>예약</CustomButton>
+      </Td>
+    </Tr>
   );
 };
 

--- a/src/components/molecules/Reservation.tsx
+++ b/src/components/molecules/Reservation.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export interface ReservationItemProps {
+  storeId: number;
+  memberId: number;
+  name: string;
+  location: string;
+  description: string;
+}
+
+const ReservationItem: React.FC<ReservationItemProps> = ({
+  description,
+  location,
+  memberId,
+  name,
+  storeId,
+}) => {
+  return <div></div>;
+};
+
+export default ReservationItem;

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box } from '@chakra-ui/react';
+import { Box, Heading } from '@chakra-ui/react';
 
 import { useAppSelector, useAppDispatch } from '../../store/index';
 
@@ -28,10 +28,13 @@ const Header = () => {
       padding={'0 20px'}
       borderBottom={'1px solid black'}
     >
-      <span>{user.username} 님 환영합니다.</span>
-      <CustomButton type="button" onClick={onClickLogOut}>
-        로그아웃
-      </CustomButton>
+      <Heading size={'md'}>매장 예약 서비스</Heading>
+      <Box display={'flex'} alignItems={'center'} gap={6}>
+        <span>{user.username} 님 환영합니다</span>
+        <CustomButton type="button" onClick={onClickLogOut}>
+          로그아웃
+        </CustomButton>
+      </Box>
     </Box>
   );
 };

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Box } from '@chakra-ui/react';
+
+import { useAppSelector, useAppDispatch } from '../../store/index';
+
+import { logoutUser } from '../../store/_reducer/user';
+
+import { initReservation } from '../../store/_reducer/reservation';
+
+import CustomButton from '../atoms/Button';
+
+const Header = () => {
+  const dispatch = useAppDispatch();
+  const { user } = useAppSelector((state) => state.user);
+
+  const onClickLogOut = () => {
+    dispatch(logoutUser());
+    dispatch(initReservation());
+  };
+
+  return (
+    <Box
+      display={'flex'}
+      justifyContent={'space-between'}
+      alignItems={'center'}
+      height={'100px'}
+      padding={'0 20px'}
+      borderBottom={'1px solid black'}
+    >
+      <span>{user.username} 님 환영합니다.</span>
+      <CustomButton type="button" onClick={onClickLogOut}>
+        로그아웃
+      </CustomButton>
+    </Box>
+  );
+};
+
+export default Header;

--- a/src/components/organisms/LoginForm.tsx
+++ b/src/components/organisms/LoginForm.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
 
+import { useAppThunkDispatch } from '../../store';
+
+import { loginUser } from '../../store/_reducer/user';
+
+import { useNavigate } from 'react-router-dom';
+
 import {
   FormControl,
   FormControlProps,
@@ -8,34 +14,35 @@ import {
 } from '@chakra-ui/react';
 
 import CustomInput from '../atoms/Input';
+
 import ButtonList from '../molecules/ButtonList';
-import { useNavigate } from 'react-router-dom';
 
 export type LoginData = {
   username: string;
   password: string;
 };
 
-export type LoginFormProps = Omit<FormControlProps, 'onSubmit'> & {
-  onSubmit: (value: LoginData) => void;
-};
+export type LoginFormProps = Omit<FormControlProps, 'onSubmit'>;
 
 const LoginForm = (props: LoginFormProps) => {
-  const { onSubmit, ...rest } = props;
+  const navigate = useNavigate();
+  const dispatch = useAppThunkDispatch();
 
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
 
-  const navigate = useNavigate();
-
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
-    onSubmit({ username, password });
+    const result = await dispatch(loginUser({ username, password })).unwrap();
+
+    if (!result?.username) {
+      alert('로그인 정보를 다시 확인해주세요.');
+    }
   };
 
   return (
     <form onSubmit={handleSubmit}>
-      <FormControl display={'flex'} flexDirection={'column'} gap={6} {...rest}>
+      <FormControl display={'flex'} flexDirection={'column'} gap={6} {...props}>
         <Box
           display={'flex'}
           flexDirection={'row'}

--- a/src/components/organisms/LoginForm.tsx
+++ b/src/components/organisms/LoginForm.tsx
@@ -8,7 +8,7 @@ import {
 } from '@chakra-ui/react';
 
 import CustomInput from '../atoms/Input';
-import ButtonList from './ButtonList';
+import ButtonList from '../molecules/ButtonList';
 import { useNavigate } from 'react-router-dom';
 
 export type LoginData = {

--- a/src/components/organisms/RegisterForm.tsx
+++ b/src/components/organisms/RegisterForm.tsx
@@ -4,6 +4,8 @@ import { useAppThunkDispatch } from '../../store';
 
 import { registerUser, MemberStatus } from '../../store/_reducer/user';
 
+import { useNavigate } from 'react-router-dom';
+
 import {
   FormControl,
   FormControlProps,
@@ -16,7 +18,6 @@ import CustomInput from '../atoms/Input';
 import CustomButton from '../atoms/Button';
 
 import CustomSelect from '../atoms/Select';
-import { useNavigate } from 'react-router-dom';
 
 export type RegisterFormProps = Omit<FormControlProps, 'onSubmit'>;
 

--- a/src/components/organisms/RegisterForm.tsx
+++ b/src/components/organisms/RegisterForm.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from 'react';
 
+import { useAppThunkDispatch } from '../../store';
+
+import { registerUser, MemberStatus } from '../../store/_reducer/user';
+
 import {
   FormControl,
   FormControlProps,
@@ -12,38 +16,35 @@ import CustomInput from '../atoms/Input';
 import CustomButton from '../atoms/Button';
 
 import CustomSelect from '../atoms/Select';
+import { useNavigate } from 'react-router-dom';
 
-type MemberStatus = 'CLIENT' | 'PARTNER';
-
-export type RegisterData = {
-  password: string;
-  username: string;
-  memberStatus: MemberStatus;
-};
-
-export type RegisterFormProps = Omit<FormControlProps, 'onSubmit'> & {
-  onSubmit: (value: RegisterData) => void;
-};
+export type RegisterFormProps = Omit<FormControlProps, 'onSubmit'>;
 
 const RegisterForm = (props: RegisterFormProps) => {
-  const { onSubmit, ...rest } = props;
+  const navigate = useNavigate();
+  const dispatch = useAppThunkDispatch();
 
   const [username, setuserName] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [status, setStatus] = useState<string>('CLIENT');
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
-    onSubmit({
-      password,
-      username,
-      memberStatus: status as MemberStatus,
-    });
+
+    const result = await dispatch(
+      registerUser({ password, username, memberStatus: status as MemberStatus })
+    ).unwrap();
+
+    console.log(result);
+
+    if (result?.username) {
+      navigate('/signin');
+    }
   };
 
   return (
     <form onSubmit={handleSubmit}>
-      <FormControl display={'flex'} flexDirection={'column'} gap={6} {...rest}>
+      <FormControl display={'flex'} flexDirection={'column'} gap={6} {...props}>
         <Box
           display={'flex'}
           flexDirection={'row'}

--- a/src/components/organisms/RegisterForm.tsx
+++ b/src/components/organisms/RegisterForm.tsx
@@ -32,8 +32,6 @@ const RegisterForm = (props: RegisterFormProps) => {
   const [password, setPassword] = useState<string>('');
   const [status, setStatus] = useState<string>('CLIENT');
 
-  console.log(status);
-
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     onSubmit({

--- a/src/components/organisms/ReservationList.tsx
+++ b/src/components/organisms/ReservationList.tsx
@@ -7,15 +7,21 @@ import { getReservation } from '../../store/_reducer/reservation';
 import { Table, TableProps } from '@chakra-ui/react';
 
 import ReservationItem from '../molecules/Reservation';
+import { useNavigate } from 'react-router-dom';
 
 interface Props {
   ListStyle?: TableProps;
 }
 
 const ReservationList = (props: Props) => {
+  const navigate = useNavigate();
   const dispatch = useAppThunkDispatch();
 
   const data = useAppSelector((state) => state.reservation);
+
+  const onClick = (id: number) => {
+    navigate(`/reservation/${id}`);
+  };
 
   useEffect(() => {
     dispatch(getReservation());
@@ -23,8 +29,13 @@ const ReservationList = (props: Props) => {
 
   return (
     <Table display={'flex'} flexDirection={'column'} {...props.ListStyle}>
-      {data?.data.map((item) => (
-        <ReservationItem key={item?.storeId} {...item} />
+      {data?.data.map((item, index) => (
+        <ReservationItem
+          key={item?.storeId}
+          index={index + 1}
+          onClick={onClick}
+          {...item}
+        />
       ))}
     </Table>
   );

--- a/src/components/organisms/ReservationList.tsx
+++ b/src/components/organisms/ReservationList.tsx
@@ -1,17 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import ReservationItem, {
+import { useAppSelector, useAppThunkDispatch } from '../../store';
+
+import {
   ReservationItemProps,
-} from '../molecules/Reservation';
+  getReservation,
+} from '../../store/_reducer/reservation';
+
+import ReservationItem from '../molecules/Reservation';
 
 type ReservationListProps = {
   data: ReservationItemProps[];
 };
 
-const ReservationList: React.FC<ReservationListProps> = ({ data }) => {
+const ReservationList: React.FC<ReservationListProps> = () => {
+  const dispatch = useAppThunkDispatch();
+
+  const data = useAppSelector((state) => state.reservation);
+
+  useEffect(() => {
+    dispatch(getReservation());
+  }, []);
+
+  console.log(data);
+
   return (
     <div>
-      {data?.map((item) => (
+      {data?.data.map((item) => (
         <ReservationItem key={item?.storeId} {...item} />
       ))}
     </div>

--- a/src/components/organisms/ReservationList.tsx
+++ b/src/components/organisms/ReservationList.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import ReservationItem, {
+  ReservationItemProps,
+} from '../molecules/Reservation';
+
+type ReservationListProps = {
+  data: ReservationItemProps[];
+};
+
+const ReservationList: React.FC<ReservationListProps> = ({ data }) => {
+  return (
+    <div>
+      {data?.map((item) => (
+        <ReservationItem key={item?.storeId} {...item} />
+      ))}
+    </div>
+  );
+};
+
+export default ReservationList;

--- a/src/components/organisms/ReservationList.tsx
+++ b/src/components/organisms/ReservationList.tsx
@@ -4,13 +4,12 @@ import { useAppSelector, useAppThunkDispatch } from '../../store';
 
 import { getReservation } from '../../store/_reducer/reservation';
 
-import { Box, BoxProps } from '@chakra-ui/react';
+import { Table, TableProps } from '@chakra-ui/react';
 
 import ReservationItem from '../molecules/Reservation';
 
 interface Props {
-  ListStyle?: BoxProps;
-  ItemStyle?: BoxProps;
+  ListStyle?: TableProps;
 }
 
 const ReservationList = (props: Props) => {
@@ -22,18 +21,12 @@ const ReservationList = (props: Props) => {
     dispatch(getReservation());
   }, []);
 
-  console.log(data);
-
   return (
-    <Box {...props.ListStyle}>
+    <Table display={'flex'} flexDirection={'column'} {...props.ListStyle}>
       {data?.data.map((item) => (
-        <ReservationItem
-          key={item?.storeId}
-          style={props.ItemStyle}
-          {...item}
-        />
+        <ReservationItem key={item?.storeId} {...item} />
       ))}
-    </Box>
+    </Table>
   );
 };
 

--- a/src/components/organisms/ReservationList.tsx
+++ b/src/components/organisms/ReservationList.tsx
@@ -2,18 +2,18 @@ import React, { useEffect } from 'react';
 
 import { useAppSelector, useAppThunkDispatch } from '../../store';
 
-import {
-  ReservationItemProps,
-  getReservation,
-} from '../../store/_reducer/reservation';
+import { getReservation } from '../../store/_reducer/reservation';
+
+import { Box, BoxProps } from '@chakra-ui/react';
 
 import ReservationItem from '../molecules/Reservation';
 
-type ReservationListProps = {
-  data: ReservationItemProps[];
-};
+interface Props {
+  ListStyle?: BoxProps;
+  ItemStyle?: BoxProps;
+}
 
-const ReservationList: React.FC<ReservationListProps> = () => {
+const ReservationList = (props: Props) => {
   const dispatch = useAppThunkDispatch();
 
   const data = useAppSelector((state) => state.reservation);
@@ -25,11 +25,15 @@ const ReservationList: React.FC<ReservationListProps> = () => {
   console.log(data);
 
   return (
-    <div>
+    <Box {...props.ListStyle}>
       {data?.data.map((item) => (
-        <ReservationItem key={item?.storeId} {...item} />
+        <ReservationItem
+          key={item?.storeId}
+          style={props.ItemStyle}
+          {...item}
+        />
       ))}
-    </div>
+    </Box>
   );
 };
 

--- a/src/components/organisms/index.tsx
+++ b/src/components/organisms/index.tsx
@@ -1,1 +1,0 @@
-export default {};

--- a/src/components/templeit/mainTemplate.tsx
+++ b/src/components/templeit/mainTemplate.tsx
@@ -7,10 +7,9 @@ import Header from '../organisms/Header';
 
 interface Props {
   ListStyle?: BoxProps;
-  ItemStyle?: BoxProps;
 }
 
-const MainTemplate: React.FC<Props> = ({ ListStyle, ItemStyle }) => {
+const MainTemplate: React.FC<Props> = ({ ListStyle }) => {
   return (
     <>
       <Header />

--- a/src/components/templeit/mainTemplate.tsx
+++ b/src/components/templeit/mainTemplate.tsx
@@ -14,7 +14,7 @@ const MainTemplate: React.FC<Props> = ({ ListStyle, ItemStyle }) => {
   return (
     <>
       <Header />
-      <ReservationList ListStyle={ListStyle} ItemStyle={ItemStyle} />;
+      <ReservationList ListStyle={ListStyle} />;
     </>
   );
 };

--- a/src/components/templeit/mainTemplate.tsx
+++ b/src/components/templeit/mainTemplate.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BoxProps } from '@chakra-ui/react';
 
 import ReservationList from '../organisms/ReservationList';
+import Header from '../organisms/Header';
 
 interface Props {
   ListStyle?: BoxProps;
@@ -10,7 +11,12 @@ interface Props {
 }
 
 const MainTemplate: React.FC<Props> = ({ ListStyle, ItemStyle }) => {
-  return <ReservationList ListStyle={ListStyle} ItemStyle={ItemStyle} />;
+  return (
+    <>
+      <Header />
+      <ReservationList ListStyle={ListStyle} ItemStyle={ItemStyle} />;
+    </>
+  );
 };
 
 export default MainTemplate;

--- a/src/components/templeit/mainTemplate.tsx
+++ b/src/components/templeit/mainTemplate.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { BoxProps } from '@chakra-ui/react';
+
+import ReservationList from '../organisms/ReservationList';
+
+interface Props {
+  ListStyle?: BoxProps;
+  ItemStyle?: BoxProps;
+}
+
+const MainTemplate: React.FC<Props> = ({ ListStyle, ItemStyle }) => {
+  return <ReservationList ListStyle={ListStyle} ItemStyle={ItemStyle} />;
+};
+
+export default MainTemplate;

--- a/src/components/templeit/signinTemplate.tsx
+++ b/src/components/templeit/signinTemplate.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import LoginForm, { LoginFormProps } from '../molecules/LoginForm';
+import LoginForm, { LoginFormProps } from '../organisms/LoginForm';
 
 import { Box, BoxProps, Heading } from '@chakra-ui/react';
 

--- a/src/components/templeit/signupTemplate.tsx
+++ b/src/components/templeit/signupTemplate.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import RegisterForm from '../molecules/RegisterForm';
+import RegisterForm from '../organisms/RegisterForm';
 
-import { RegisterFormProps } from '../molecules/RegisterForm';
+import { RegisterFormProps } from '../organisms/RegisterForm';
 
 import { Box, BoxProps, Heading } from '@chakra-ui/react';
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,13 +2,24 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../store';
 
-export default function useAuth() {
+export default function useAuth(option: boolean | null) {
+  /*
+    null : 자유롭게 접근 가능
+    true :  로그인한 유저만 출입 가능
+    false : 로그인한 유저는 출입 불가능
+    */
   const isLogin = useAppSelector((state) => state.user.isLogin);
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isLogin) {
-      navigate('/signin');
+    if (option) {
+      if (!isLogin) {
+        navigate('/signin');
+      }
+    } else {
+      if (isLogin) {
+        navigate('/');
+      }
     }
   }, [isLogin]);
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppSelector } from '../store';
+
+export default function useAuth() {
+  const isLogin = useAppSelector((state) => state.user.isLogin);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLogin) {
+      navigate('/signin');
+    }
+  }, [isLogin]);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,9 @@ import { App } from './App';
 import { BrowserRouter } from 'react-router-dom';
 import { ColorModeScript } from '@chakra-ui/react';
 
+import { Provider } from 'react-redux';
+import store from './store';
+
 import reportWebVitals from './reportWebVitals';
 
 import * as React from 'react';
@@ -15,8 +18,10 @@ const root = ReactDOM.createRoot(container);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <ColorModeScript />
-      <App />
+      <Provider store={store}>
+        <ColorModeScript />
+        <App />
+      </Provider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter } from 'react-router-dom';
 import { ColorModeScript } from '@chakra-ui/react';
 
 import { Provider } from 'react-redux';
+import { persistStore } from 'redux-persist';
+import { PersistGate } from 'redux-persist/integration/react';
 import store from './store';
 
 import reportWebVitals from './reportWebVitals';
@@ -10,6 +12,8 @@ import reportWebVitals from './reportWebVitals';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import * as serviceWorker from './serviceWorker';
+
+export const persistor = persistStore(store);
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Failed to find the root element');
@@ -19,8 +23,10 @@ root.render(
   <React.StrictMode>
     <BrowserRouter>
       <Provider store={store}>
-        <ColorModeScript />
-        <App />
+        <PersistGate loading={null} persistor={persistor}>
+          <ColorModeScript />
+          <App />
+        </PersistGate>
       </Provider>
     </BrowserRouter>
   </React.StrictMode>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
+import useAuth from '../hooks/useAuth';
+
 const Index = () => {
+  useAuth();
+
   return <div>Hello world!</div>;
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,38 @@
 import React from 'react';
 
+import { useAppDispatch } from '../store';
+
+import { logoutUser } from '../store/_reducer/user';
+
+import { initReservation } from '../store/_reducer/reservation';
+
 import useAuth from '../hooks/useAuth';
 
-import ReservationList from '../components/organisms/ReservationList';
+import CustomButton from '../components/atoms/Button';
+
+import MainTemplate from '../components/templeit/mainTemplate';
 
 const Index = () => {
   useAuth(true);
 
-  return <ReservationList data={[]} />;
+  const dispatch = useAppDispatch();
+
+  const onClickLogOut = () => {
+    dispatch(logoutUser());
+    dispatch(initReservation());
+  };
+
+  return (
+    <>
+      <CustomButton type="button" onClick={onClickLogOut}>
+        로그아웃
+      </CustomButton>
+      <MainTemplate
+        ListStyle={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}
+        ItemStyle={{ display: 'flex', gap: 6 }}
+      />
+    </>
+  );
 };
 
 export default Index;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,37 +1,17 @@
 import React from 'react';
 
-import { useAppDispatch } from '../store';
-
-import { logoutUser } from '../store/_reducer/user';
-
-import { initReservation } from '../store/_reducer/reservation';
-
 import useAuth from '../hooks/useAuth';
-
-import CustomButton from '../components/atoms/Button';
 
 import MainTemplate from '../components/templeit/mainTemplate';
 
 const Index = () => {
   useAuth(true);
 
-  const dispatch = useAppDispatch();
-
-  const onClickLogOut = () => {
-    dispatch(logoutUser());
-    dispatch(initReservation());
-  };
-
   return (
-    <>
-      <CustomButton type="button" onClick={onClickLogOut}>
-        로그아웃
-      </CustomButton>
-      <MainTemplate
-        ListStyle={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}
-        ItemStyle={{ display: 'flex', gap: 6 }}
-      />
-    </>
+    <MainTemplate
+      ListStyle={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}
+      ItemStyle={{ display: 'flex', gap: 6 }}
+    />
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import useAuth from '../hooks/useAuth';
 
 const Index = () => {
-  useAuth();
+  useAuth(true);
 
   return <div>Hello world!</div>;
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,12 +7,7 @@ import MainTemplate from '../components/templeit/mainTemplate';
 const Index = () => {
   useAuth(true);
 
-  return (
-    <MainTemplate
-      ListStyle={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}
-      ItemStyle={{ display: 'flex', gap: 6 }}
-    />
-  );
+  return <MainTemplate />;
 };
 
 export default Index;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import useAuth from '../hooks/useAuth';
 
-const Index = () => {
-  useAuth(true);
+import ReservationList from '../components/organisms/ReservationList';
 
-  return <div>Hello world!</div>;
+const Index = () => {
+  useAuth(null);
+
+  return <ReservationList data={[]} />;
 };
 
 export default Index;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ import useAuth from '../hooks/useAuth';
 import ReservationList from '../components/organisms/ReservationList';
 
 const Index = () => {
-  useAuth(null);
+  useAuth(true);
 
   return <ReservationList data={[]} />;
 };

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -2,15 +2,24 @@ import React from 'react';
 
 import { LoginData } from '../../components/molecules/LoginForm';
 
-import SigninTemplate from '../../components/templeit/signinTemplate';
+import { useAppThunkDispatch } from '../../store';
+
+import { loginUser } from '../../store/_reducer/user';
 
 import useAuth from '../../hooks/useAuth';
 
+import SigninTemplate from '../../components/templeit/signinTemplate';
+
 const SigninIndex = () => {
   useAuth(false);
+  const dispatch = useAppThunkDispatch();
+
   const onSubmit = async (value: LoginData) => {
-    // api 연동
+    if (!value.password || !value.username) return;
+
+    dispatch(loginUser(value));
   };
+
   return (
     <SigninTemplate
       templateStyle={{

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -4,7 +4,10 @@ import { LoginData } from '../../components/molecules/LoginForm';
 
 import SigninTemplate from '../../components/templeit/signinTemplate';
 
+import useAuth from '../../hooks/useAuth';
+
 const SigninIndex = () => {
+  useAuth(false);
   const onSubmit = async (value: LoginData) => {
     // api 연동
   };

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,24 +1,11 @@
 import React from 'react';
 
-import { LoginData } from '../../components/organisms/LoginForm';
-
-import { useAppThunkDispatch } from '../../store';
-
-import { loginUser } from '../../store/_reducer/user';
-
 import useAuth from '../../hooks/useAuth';
 
 import SigninTemplate from '../../components/templeit/signinTemplate';
 
 const SigninIndex = () => {
   useAuth(false);
-  const dispatch = useAppThunkDispatch();
-
-  const onSubmit = async (value: LoginData) => {
-    if (!value.password || !value.username) return;
-
-    dispatch(loginUser(value));
-  };
 
   return (
     <SigninTemplate
@@ -30,7 +17,6 @@ const SigninIndex = () => {
         gap: 6,
       }}
       loginForm={{
-        onSubmit,
         whiteSpace: 'nowrap',
       }}
     />

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LoginData } from '../../components/molecules/LoginForm';
+import { LoginData } from '../../components/organisms/LoginForm';
 
 import { useAppThunkDispatch } from '../../store';
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
-import SignupTemplate from '../../components/templeit/signupTemplate';
-
 import { RegisterData } from '../../components/molecules/RegisterForm';
 
+import SignupTemplate from '../../components/templeit/signupTemplate';
+
+import useAuth from '../../hooks/useAuth';
+
 const SignUpIndex = () => {
+  useAuth(false);
   const onSubmit = async (value: RegisterData) => {
     try {
       const response = await fetch('http://3.39.231.227:8080/member', {

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { RegisterData } from '../../components/molecules/RegisterForm';
+import { RegisterData } from '../../components/organisms/RegisterForm';
 
 import SignupTemplate from '../../components/templeit/signupTemplate';
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,29 +1,11 @@
 import React from 'react';
 
-import { RegisterData } from '../../components/organisms/RegisterForm';
-
 import SignupTemplate from '../../components/templeit/signupTemplate';
 
 import useAuth from '../../hooks/useAuth';
 
 const SignUpIndex = () => {
   useAuth(false);
-  const onSubmit = async (value: RegisterData) => {
-    try {
-      const response = await fetch('http://3.39.231.227:8080/member', {
-        method: 'POST',
-        body: JSON.stringify(value),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      const result = await response.json();
-      console.log(result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
 
   return (
     <SignupTemplate
@@ -35,7 +17,6 @@ const SignUpIndex = () => {
         gap: 6,
       }}
       registerForm={{
-        onSubmit,
         whiteSpace: 'nowrap',
       }}
     />

--- a/src/store/_reducer/reservation.tsx
+++ b/src/store/_reducer/reservation.tsx
@@ -69,7 +69,11 @@ export const getReservation = createAsyncThunk<
 export const reservationSlice = createSlice({
   name: 'reservation',
   initialState,
-  reducers: {},
+  reducers: {
+    initReservation: (state: StateProps) => {
+      return initialState;
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(getReservation.fulfilled, (_, action) => {
       return action.payload;
@@ -83,6 +87,6 @@ export const reservationSlice = createSlice({
   },
 });
 
-export const {} = reservationSlice.actions;
+export const { initReservation } = reservationSlice.actions;
 
 export default reservationSlice.reducer;

--- a/src/store/_reducer/reservation.tsx
+++ b/src/store/_reducer/reservation.tsx
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
-import { RootState } from '..';
+import { AppDispatch, RootState } from '..';
 
 export interface ReservationItemProps {
   storeId: number;
@@ -46,25 +46,30 @@ const dummy: StateProps = {
   currentPage: 1,
 };
 
-export const getReservation = createAsyncThunk<
-  any,
-  undefined,
-  { state: RootState; rejectValue: { message: string } }
->('reservation/getReservation', async (_, thunkAPI) => {
-  try {
-    const isLogin = thunkAPI.getState().user.isLogin;
+const createAppAsyncThunk = createAsyncThunk.withTypes<{
+  state: RootState;
+  dispatch: AppDispatch;
+  rejectValue: { message: string };
+}>();
 
-    if (!isLogin) {
-      return thunkAPI.rejectWithValue({
-        message: '로그인이 필요한 서비스 입니다.',
-      });
+export const getReservation = createAppAsyncThunk(
+  'reservation/getReservation',
+  async (_, thunkAPI) => {
+    try {
+      const isLogin = thunkAPI.getState().user.isLogin;
+
+      if (!isLogin) {
+        return thunkAPI.rejectWithValue({
+          message: '로그인이 필요한 서비스 입니다.',
+        });
+      }
+      // 로그인만 되어있다면 데이터를 얻을 수 있다.
+      return dummy;
+    } catch (error) {
+      console.log(error);
     }
-    // 로그인만 되어있다면 데이터를 얻을 수 있다.
-    return dummy;
-  } catch (error) {
-    console.log(error);
   }
-});
+);
 
 export const reservationSlice = createSlice({
   name: 'reservation',

--- a/src/store/_reducer/reservation.tsx
+++ b/src/store/_reducer/reservation.tsx
@@ -59,6 +59,7 @@ export const getReservation = createAsyncThunk<
         message: '로그인이 필요한 서비스 입니다.',
       });
     }
+    // 로그인만 되어있다면 데이터를 얻을 수 있다.
     return dummy;
   } catch (error) {
     console.log(error);

--- a/src/store/_reducer/reservation.tsx
+++ b/src/store/_reducer/reservation.tsx
@@ -1,0 +1,87 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import { RootState } from '..';
+
+export interface ReservationItemProps {
+  storeId: number;
+  memberId: number;
+  name: string;
+  location: string;
+  description: string;
+}
+
+interface StateProps {
+  totalItems: number;
+  data: ReservationItemProps[];
+  totalPages: number;
+  currentPage: number;
+}
+
+const initialState: StateProps = {
+  currentPage: 0,
+  data: [],
+  totalItems: 0,
+  totalPages: 0,
+};
+
+const dummy: StateProps = {
+  totalItems: 2,
+  data: [
+    {
+      storeId: 1,
+      memberId: 1,
+      name: 'testStore1',
+      location: 'seoul',
+      description: 'test description1',
+    },
+    {
+      storeId: 2,
+      memberId: 2,
+      name: 'testStore2',
+      location: 'seoul',
+      description: 'test description2',
+    },
+  ],
+  totalPages: 1,
+  currentPage: 1,
+};
+
+export const getReservation = createAsyncThunk<
+  any,
+  undefined,
+  { state: RootState; rejectValue: { message: string } }
+>('reservation/getReservation', async (_, thunkAPI) => {
+  try {
+    const isLogin = thunkAPI.getState().user.isLogin;
+
+    if (!isLogin) {
+      return thunkAPI.rejectWithValue({
+        message: '로그인이 필요한 서비스 입니다.',
+      });
+    }
+    return dummy;
+  } catch (error) {
+    console.log(error);
+  }
+});
+
+export const reservationSlice = createSlice({
+  name: 'reservation',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(getReservation.fulfilled, (_, action) => {
+      return action.payload;
+    });
+    builder.addCase(getReservation.rejected, (_, action) => {
+      if (action.payload?.message) {
+        console.log(action.payload?.message);
+        return initialState;
+      }
+    });
+  },
+});
+
+export const {} = reservationSlice.actions;
+
+export default reservationSlice.reducer;

--- a/src/store/_reducer/user.tsx
+++ b/src/store/_reducer/user.tsx
@@ -14,7 +14,7 @@ interface UserState {
 export type StateProps = UserState;
 
 const initialState: UserState = {
-  isLogin: true,
+  isLogin: false,
   user: {
     email: '',
     name: '',

--- a/src/store/_reducer/user.tsx
+++ b/src/store/_reducer/user.tsx
@@ -14,7 +14,7 @@ interface UserState {
 export type StateProps = UserState;
 
 const initialState: UserState = {
-  isLogin: false,
+  isLogin: true,
   user: {
     email: '',
     name: '',

--- a/src/store/_reducer/user.tsx
+++ b/src/store/_reducer/user.tsx
@@ -5,9 +5,8 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 interface UserState {
   isLogin: boolean;
   user: {
-    email: string;
+    username: string;
     password: string;
-    name: string;
   };
 }
 
@@ -16,30 +15,17 @@ export type StateProps = UserState;
 const initialState: UserState = {
   isLogin: false,
   user: {
-    email: '',
-    name: '',
+    username: '',
     password: '',
   },
 };
 
 export const loginUser = createAsyncThunk(
   'user/signupUser',
-  async (userData: { email: string; password: string }, thunkAPI) => {
+  async (userData: { username: string; password: string }, thunkAPI) => {
     try {
-      const response = await fetch('url', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(userData),
-      });
-
-      const result = await response.json();
-      if (response.status === 201) {
-        return { ...result }; // reducer의 action.payload
-      } else {
-        throw new Error();
-      }
+      // 일단 로그인이 무조건 성공함.
+      return userData;
     } catch (e: any) {
       throw thunkAPI.rejectWithValue(e.response.data);
     }
@@ -53,8 +39,7 @@ export const userSlice = createSlice({
     logoutUser: (state: StateProps) => {
       state.isLogin = false;
       state.user = {
-        email: '',
-        name: '',
+        username: '',
         password: '',
       };
     },

--- a/src/store/_reducer/user.tsx
+++ b/src/store/_reducer/user.tsx
@@ -24,7 +24,7 @@ const initialState: UserState = {
 
 export const loginUser = createAsyncThunk(
   'user/signupUser',
-  async (userData: { email: string; password: string }) => {
+  async (userData: { email: string; password: string }, thunkAPI) => {
     try {
       const response = await fetch('url', {
         method: 'POST',
@@ -41,8 +41,7 @@ export const loginUser = createAsyncThunk(
         throw new Error();
       }
     } catch (e: any) {
-      console.log('Error', e.response.data);
-      throw new Error();
+      throw thunkAPI.rejectWithValue(e.response.data);
     }
   }
 );

--- a/src/store/_reducer/user.tsx
+++ b/src/store/_reducer/user.tsx
@@ -12,6 +12,14 @@ interface UserState {
 
 export type StateProps = UserState;
 
+export type MemberStatus = 'CLIENT' | 'PARTNER';
+
+export type RegisterData = {
+  password: string;
+  username: string;
+  memberStatus: MemberStatus;
+};
+
 const initialState: UserState = {
   isLogin: false,
   user: {
@@ -25,6 +33,18 @@ export const loginUser = createAsyncThunk(
   async (userData: { username: string; password: string }, thunkAPI) => {
     try {
       // 일단 로그인이 무조건 성공함.
+      return userData;
+    } catch (e: any) {
+      throw thunkAPI.rejectWithValue(e.response.data);
+    }
+  }
+);
+
+export const registerUser = createAsyncThunk(
+  'user/registerUser',
+  async (userData: RegisterData, thunkAPI) => {
+    try {
+      // 일단 회원가입 성공
       return userData;
     } catch (e: any) {
       throw thunkAPI.rejectWithValue(e.response.data);
@@ -58,6 +78,12 @@ export const userSlice = createSlice({
     // 실패
     builder.addCase(loginUser.rejected, (state, action) => {
       state.isLogin = false;
+    });
+    builder.addCase(registerUser.fulfilled, (state, action) => {
+      console.log('회원가입 성공');
+    });
+    builder.addCase(registerUser.rejected, (state, action) => {
+      console.log(action.payload);
     });
   },
 });

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,4 +1,9 @@
-import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import {
+  AnyAction,
+  combineReducers,
+  configureStore,
+  ThunkDispatch,
+} from '@reduxjs/toolkit';
 import { useDispatch, useSelector } from 'react-redux';
 import type { TypedUseSelectorHook } from 'react-redux';
 import { persistReducer } from 'redux-persist';
@@ -8,15 +13,17 @@ import logger from 'redux-logger';
 import storage from 'redux-persist/lib/storage';
 
 import userReducer from './_reducer/user';
+import reservationReducer from './_reducer/reservation';
 
 const reducers = combineReducers({
   user: userReducer,
+  reservation: reservationReducer,
 });
 
 const persistConfig = {
   key: 'root',
   storage, // 로컬 스토리지에 저장
-  whitelist: ['user'],
+  whitelist: ['user', 'reservation'],
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers);
@@ -29,7 +36,9 @@ const store = configureStore({
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+export type AppThunkDispatch = ThunkDispatch<RootState, any, AnyAction>;
 export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppThunkDispatch = () => useDispatch<AppThunkDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 export default store;


### PR DESCRIPTION
### PR 타입
[ v ] 기능 추가
[] 기능 삭제
[] 버그 수정
[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 브랜치
feat/main -> develop

### 변경 사항
1. 매장 리스트 페이지 추가
2. 헤더 추가
3. reservation slice (store) 추가, 매장 조회 (dummy data)
4. 로그인, 회원가입 redux thunk 로 연동 (api x)
5. 인증 처리 (로그인 이후에 매장 리스트 페이지 접근 가능)


